### PR TITLE
Wrap adaptive pooling methods in a nn.ModuleList

### DIFF
--- a/torcharch/modules/conv.py
+++ b/torcharch/modules/conv.py
@@ -25,7 +25,7 @@ class SpatialPyramidPooling(nn.Module):
             pool_func = nn.AdaptiveAvgPool2d
         else:
             raise NotImplementedError(f"Unknown pooling mode '{mode}', expected 'max' or 'avg'")
-        self.pools = []
+        self.pools = nn.ModuleList([])
         for p in num_pools:
             side_length = sqrt(p)
             if not side_length.is_integer():


### PR DESCRIPTION
See https://discuss.pytorch.org/t/when-should-i-use-nn-modulelist-and-when-should-i-use-nn-sequential/5463/4 for more details on why nn.Modules should be placed inside a nn.ModuleList and not a raw python list.
